### PR TITLE
Make docker optional, use sqlite by default 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 data/drug-ndc-20200504.json
 log/
+drugs.db

--- a/connect_db.py
+++ b/connect_db.py
@@ -1,3 +1,4 @@
+import os
 import requests
 import sys
 from sqlalchemy import create_engine, Column, Integer, String
@@ -24,7 +25,7 @@ class Drugs(Base):
 def main():
     # Connect to DB
     sys.stderr.write("Connecting to the DB")
-    engine = create_engine('mysql+pymysql://admin:admin@db:3306/drugs')
+    engine = create_engine(os.environ.get('DB_URI', 'sqlite:///drugs.db'))
     Base.metadata.create_all(engine)
     Session = sessionmaker(bind=engine)
     session = Session()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,10 +17,11 @@ services:
             - ./data:/data
         command:
             - '--secure-file-priv=/data'
-        
-    
+
     drugs:
         container_name: drugs
+        environment:
+          DB_URI: 'mysql+pymysql://admin:admin@db:3306/drugs'
         build:
             context: .
             dockerfile: Dockerfile

--- a/server.py
+++ b/server.py
@@ -1,3 +1,4 @@
+import os
 import cherrypy
 from cherrypy.process import wspbus, plugins
 from connect_db import Drugs
@@ -7,7 +8,7 @@ from sqlalchemy.orm import sessionmaker, scoped_session
 class DrugsList(Drugs):
     def __init__(self):
         Drugs.__init__(self)
-    
+
     @staticmethod
     def listDrugs(session):
         return session.query(DrugsList.brand_name) \
@@ -18,15 +19,15 @@ class SAEnginePlugin(plugins.SimplePlugin):
         plugins.SimplePlugin.__init__(self, bus)
         self.sa_engine = None
         self.bus.subscribe("bind", self.bind)
-    
+
     def start(self):
-        self.sa_engine = create_engine('mysql+pymysql://admin:admin@db:3306/drugs')
-    
+        self.sa_engine = create_engine(os.environ.get('DB_URI', 'sqlite:///drugs.db'))
+
     def stop(self):
         if self.sa_engine:
             self.sa_engine.dispose()
             self.sa_engine = None
-    
+
     def bind(self, session):
         session.configure(bind=self.sa_engine)
 
@@ -35,7 +36,7 @@ class SATool(cherrypy.Tool):
         cherrypy.Tool.__init__(self, 'on_start_resource',
                                self.bind_session,
                                priority=20)
-    
+
         self.session = scoped_session(sessionmaker(autoflush=True, autocommit=False))
 
     def _setup(self):


### PR DESCRIPTION
This PR doesn't address a specific issue, but instead makes this repo a bit more friendly for non-docker users. This does not need to be merged but felt it would be nice to have. 

Using the python `os` module the database engine will be created based off the environmental variable `DB_URI`. This will default to using an sqlite database with `sqlite:///drugs.db` when `run.py` is executed directly. When used with docker this env var will default to `mysql+pymysql://admin:admin@db:3306/drugs` (in the future we should really remove hard coded urls like this as they are a security risk and code configuration with env vars completely). 

For non docker usage one simply needs to install the python dependencies (preferably with a virtualenv) using the requirements file and then execute `python run.py`. The run script defaults to a 15 sec sleep so be aware that no output will generate for 15 sec. 

There are differences between sqlite and mysql so this may be a very short term solution. 