### PR TITLE
Add config.ini settings for allowing user to default docker build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
-data/drug-ndc-20200504.json
+data/
 log/
+*.pyc
+*/__pycache__/

--- a/connect_db.py
+++ b/connect_db.py
@@ -35,7 +35,7 @@ def main():
     if settings == 'yes':
         engine = create_engine('mysql+pymysql://admin:admin@db:3306/drugs')  # connect to Docker MySQL DB
     else:
-        engine = create_engine('sqlite://')  # connect to in-memory SQLITE DB
+        engine = create_engine('sqlite:///data/drugs.db')  # connect to /data/drugs.db SQLITE DB
     Base.metadata.create_all(engine)
     Session = sessionmaker(bind=engine)
     session = Session()

--- a/connect_db.py
+++ b/connect_db.py
@@ -1,8 +1,16 @@
 import requests
 import sys
+import configparser
 from sqlalchemy import create_engine, Column, Integer, String
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
+
+
+# Config settings under [database] section in settings.ini
+def load_config():
+    config = configparser.ConfigParser()
+    config.read('settings.ini')
+    return config['database']['use_docker']
 
 
 # Table schema
@@ -24,7 +32,11 @@ class Drugs(Base):
 def main():
     # Connect to DB
     sys.stderr.write("Connecting to the DB")
-    engine = create_engine('mysql+pymysql://admin:admin@db:3306/drugs')
+    settings = load_config()
+    if settings == 'yes':
+        engine = create_engine('mysql+pymysql://admin:admin@db:3306/drugs')
+    else:
+        engine = create_engine('sqlite://')
     Base.metadata.create_all(engine)
     Session = sessionmaker(bind=engine)
     session = Session()

--- a/connect_db.py
+++ b/connect_db.py
@@ -31,12 +31,11 @@ class Drugs(Base):
 
 def main():
     # Connect to DB
-    sys.stderr.write("Connecting to the DB")
     settings = load_config()
     if settings == 'yes':
-        engine = create_engine('mysql+pymysql://admin:admin@db:3306/drugs')
+        engine = create_engine('mysql+pymysql://admin:admin@db:3306/drugs')  # connect to Docker MySQL DB
     else:
-        engine = create_engine('sqlite://')
+        engine = create_engine('sqlite://')  # connect to in-memory SQLITE DB
     Base.metadata.create_all(engine)
     Session = sessionmaker(bind=engine)
     session = Session()

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,36 @@
+version: '3.7'
+
+
+services:
+
+
+    db_drugs:
+        image: mysql:8
+        container_name: db_drugs
+        environment:
+            MYSQL_DATABASE: drugs
+            MYSQL_USER: admin
+            MYSQL_PASSWORD: admin
+            MYSQL_ROOT_PASSWORD: supersecret
+        volumes:
+            - db_open_data:/var/lib/mysql
+            - ./data:/data
+        command:
+            - '--secure-file-priv=/data'
+        
+    
+    drugs:
+        container_name: drugs
+        build:
+            context: .
+            dockerfile: Dockerfile
+        ports:
+            - 8082:8080
+        depends_on:
+            - db_drugs
+        links:
+            - "db_drugs:db"
+
+
+volumes:
+    db_open_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,23 +2,7 @@ version: '3.7'
 
 
 services:
-
-
-    db_drugs:
-        image: mysql:8
-        container_name: db_drugs
-        environment:
-            MYSQL_DATABASE: drugs
-            MYSQL_USER: admin
-            MYSQL_PASSWORD: admin
-            MYSQL_ROOT_PASSWORD: supersecret
-        volumes:
-            - db_open_data:/var/lib/mysql
-            - ./data:/data
-        command:
-            - '--secure-file-priv=/data'
-        
-    
+   
     drugs:
         container_name: drugs
         build:
@@ -26,11 +10,5 @@ services:
             dockerfile: Dockerfile
         ports:
             - 8082:8080
-        depends_on:
-            - db_drugs
-        links:
-            - "db_drugs:db"
-
-
-volumes:
-    db_open_data:
+        volumes:
+            - ./data:/app/data

--- a/run.py
+++ b/run.py
@@ -21,8 +21,9 @@ def main():
         logger.error("Second attempt connecting to database\n")
         session = connect_db()
 
-    cherrypy_server()
     load_ndcs(session)
+    cherrypy_server()
+
 
 
 if __name__ == "__main__":

--- a/server.py
+++ b/server.py
@@ -33,7 +33,7 @@ class SAEnginePlugin(plugins.SimplePlugin):
         if settings == 'yes':
             self.sa_engine = create_engine('mysql+pymysql://admin:admin@db:3306/drugs')
         else:
-            self.sa_engine = create_engine('sqlite://')
+            self.sa_engine = create_engine('sqlite:///data/drugs.db')
     
     def stop(self):
         if self.sa_engine:

--- a/server.py
+++ b/server.py
@@ -1,8 +1,17 @@
 import cherrypy
+import configparser
 from cherrypy.process import wspbus, plugins
 from connect_db import Drugs
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, scoped_session
+
+
+# Config settings under [database] section in settings.ini
+def load_config():
+    config = configparser.ConfigParser()
+    config.read('settings.ini')
+    return config['database']['use_docker']
+
 
 class DrugsList(Drugs):
     def __init__(self):
@@ -20,7 +29,11 @@ class SAEnginePlugin(plugins.SimplePlugin):
         self.bus.subscribe("bind", self.bind)
     
     def start(self):
-        self.sa_engine = create_engine('mysql+pymysql://admin:admin@db:3306/drugs')
+        settings = load_config()
+        if settings == 'yes':
+            self.sa_engine = create_engine('mysql+pymysql://admin:admin@db:3306/drugs')
+        else:
+            self.sa_engine = create_engine('sqlite://')
     
     def stop(self):
         if self.sa_engine:

--- a/settings.ini
+++ b/settings.ini
@@ -1,0 +1,2 @@
+[database]
+use_docker = yes  # yes | no 

--- a/settings.ini
+++ b/settings.ini
@@ -1,2 +1,2 @@
 [database]
-use_docker = yes  # yes | no 
+use_docker = no  # yes | no 


### PR DESCRIPTION
Default docker-compose for 'production' uses sqlite3.
Docker-compose override uses mysql database in adjacent docker container.
Config.ini file captures `use_docker: no # Options: yes|no`
Config.ini read and logic determines which DB to attach.  